### PR TITLE
Fix "get started" link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ By submitting a pull request, you represent that you have the right to license y
 
 ---
 
-For more information about how to contribute, please refer to the [Contributors -> Get started](https://docs.next.tuist.io/documentation/tuist/contributing---get-started) section of the documentation.
+For more information about how to contribute, please refer to the [Contributors -> Get started](https://docs.tuist.io/documentation/tuist/get-started-as-contributor) section of the documentation.
 
 ---
 


### PR DESCRIPTION
### Short description 📝

This PR fixes a link in the contributing docs that seems to be pointed to an old link and currently gives an SSL error. [This previous PR](https://github.com/tuist/tuist/pull/5775) fixed some similar links, so I assume this one was just missed and I'm updating it similarly. 